### PR TITLE
Resolve Cannot find 'isPresented' in scope

### DIFF
--- a/Sources/WindowKit/WindowCover/WindowItemCover.swift
+++ b/Sources/WindowKit/WindowCover/WindowItemCover.swift
@@ -55,17 +55,10 @@ struct WindowItemCover<WindowItem, WindowContent>: ViewModifier where WindowItem
                 }
         } else {
             content
-                #if os(visionOS)
-                .onChange(of: isPresented) { _, value in
-                    guard value else { return }
-                    Logger.main.error("[Presentation] Attempt to present a window cover without a window scene.")
-                }
-                #else
                 .onChange(of: item?.id) { value in
                     guard value != nil else { return }
                     Logger.main.error("[Presentation] Attempt to present a window cover without a window scene.")
                 }
-                #endif
                 .onAppear {
                     guard item != nil else { return }
                     Logger.main.error("[Presentation] Attempt to present a window cover without a window scene.")

--- a/Sources/WindowKit/WindowCover/WindowItemCover.swift
+++ b/Sources/WindowKit/WindowCover/WindowItemCover.swift
@@ -55,10 +55,17 @@ struct WindowItemCover<WindowItem, WindowContent>: ViewModifier where WindowItem
                 }
         } else {
             content
+                #if os(visionOS)
+                .onChange(of: item?.id) { _, value in
+                    guard value != nil else { return }
+                    Logger.main.error("[Presentation] Attempt to present a window cover without a window scene.")
+                }
+                #else
                 .onChange(of: item?.id) { value in
                     guard value != nil else { return }
                     Logger.main.error("[Presentation] Attempt to present a window cover without a window scene.")
                 }
+                #endif
                 .onAppear {
                     guard item != nil else { return }
                     Logger.main.error("[Presentation] Attempt to present a window cover without a window scene.")


### PR DESCRIPTION
In visionOS I'm seeing Cannot find 'isPresented' in scope. Guessing this was some old code but looks like it now uses item?.id.