### PR TITLE
Fix PassthroughWindow on iOS 26

### DIFF
--- a/Sources/WindowKit/WindowOverlay/PassthroughWindow.swift
+++ b/Sources/WindowKit/WindowOverlay/PassthroughWindow.swift
@@ -28,6 +28,10 @@ final class PassthroughWindow: UIWindow {
             return hitView
         }
         
+        if #available(iOS 26, *) {
+            return rootView.layer.hitTest(point)?.name == nil ? rootView : nil
+        }
+        
         defer {
             allowNextRootHit = rootView.subviews.contains(hitView)
         }


### PR DESCRIPTION
On iOS 26, there is an issue where PassthroughWindow fails to recognize touch events in areas beneath the window.

As discussed in the following Stack Overflow post: https://stackoverflow.com/questions/79768526

Modifying the hitTest implementation of PassthroughWindow to use a layer-based approach restores the previous behavior. This change applies that fix.